### PR TITLE
Implement S3 storage that auto-casts to bytes if needed

### DIFF
--- a/chamber/storages/boto3.py
+++ b/chamber/storages/boto3.py
@@ -1,0 +1,30 @@
+from django.core.files.base import ContentFile
+
+from storages.backends.s3boto3 import S3Boto3Storage
+
+
+__all__ = (
+    'S3Storage',
+    'force_bytes_content',
+)
+
+
+def force_bytes_content(content, blocksize=1024):
+    '''Returns a tuple of content (file-like object) and bool indicating wheter the content has been casted or not'''
+    block = content.read(blocksize)
+    content.seek(0)
+
+    if not isinstance(block, bytes):
+        _content = bytes(
+            content.read(),
+            'utf-8' if not hasattr(content, 'encoding') or content.encoding is None else content.encoding,
+        )
+        return ContentFile(_content), True
+    return content, False
+
+
+class S3Storage(S3Boto3Storage):
+
+    def save(self, name, content, max_length=None):
+        content, _ = force_bytes_content(content)
+        return super().save(name, content, max_length)

--- a/example/dj/apps/test_chamber/tests/__init__.py
+++ b/example/dj/apps/test_chamber/tests/__init__.py
@@ -4,4 +4,5 @@ from .importers import *  # NOQA
 from .models import *  # NOQA
 from .multidomains import *  # NOQA
 from .shortcuts import *  # NOQA
+from .storages import *  # NOQA
 from .utils import *  # NOQA

--- a/example/dj/apps/test_chamber/tests/storages/__init__.py
+++ b/example/dj/apps/test_chamber/tests/storages/__init__.py
@@ -1,0 +1,1 @@
+from .boto3 import *  # NOQA

--- a/example/dj/apps/test_chamber/tests/storages/boto3.py
+++ b/example/dj/apps/test_chamber/tests/storages/boto3.py
@@ -1,0 +1,23 @@
+from django.core.files.base import ContentFile
+from django.test import TestCase
+
+from chamber.storages.boto3 import force_bytes_content
+
+from germanium.decorators import data_provider
+
+
+class S3StorageTestCase(TestCase):
+
+    TEST_DATA = (
+        ('Hello, this is str content.', b'Hello, this is str content.', True),
+        (b'Hello, this is bytes content.', b'Hello, this is bytes content.', False),
+    )
+
+    @data_provider(TEST_DATA)
+    def test_s3storage_casts_content_to_bytes_if_needed(self, content, content_result, should_cast):
+        file = ContentFile(content)
+        result, casted = force_bytes_content(file)
+        casted_content = result.read()
+        self.assertEqual(should_cast, casted)
+        self.assertEqual(bytes, type(casted_content))
+        self.assertEqual(content_result, casted_content)

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -8,4 +8,6 @@ coveralls==1.1
 filemagic==1.6
 unidecode==0.4.20
 pillow==4.1.1
+django-storages==1.7.1
+boto3==1.9.209
 -e ../

--- a/setup.py
+++ b/setup.py
@@ -31,4 +31,7 @@ setup(
         'six>=1.10.0',
         'filemagic>=1.6',
     ],
+    extras_require={
+        'boto3storage': ['django-storages<2.0', 'boto3'],
+    },
 )


### PR DESCRIPTION
This S3 storage actually overrides the one from django-storages and just casts file contents to bytes if needed so it can be used with boto3.