### PR TITLE
Fix Django version checking

### DIFF
--- a/chamber/models/__init__.py
+++ b/chamber/models/__init__.py
@@ -9,6 +9,7 @@ from django.db import models, transaction
 from django.db.models.base import ModelBase
 from django.utils.translation import ugettext_lazy as _
 from django.utils.functional import cached_property
+from django.utils.version import get_main_version
 
 from chamber.exceptions import PersistenceException
 from chamber.patch import Options
@@ -457,7 +458,7 @@ class SmartModel(AuditModel, metaclass=SmartModelBase):
         self.is_changing = True
         self.changed_fields = DynamicChangedFields(self)
 
-        if StrictVersion(django.get_version()) < StrictVersion('2.0'):
+        if StrictVersion(get_main_version()) < StrictVersion('2.0'):
             for field in [f for f in self._meta.get_fields() if f.is_relation]:
                 # For Generic relation related model is None
                 # https://docs.djangoproject.com/en/2.1/ref/models/meta/#migrating-from-the-old-api


### PR DESCRIPTION
Alpha versions of Django return version in form `3.0.dev20190416121426` which `StrictVersions` refuses to parse:
```
Traceback (most recent call last):
  File "/home/travis/build/druids/django-pynotify/example/tests/test_models.py", line 123, in test_generated_fields_should_use_template_for_rendering
    self.notification.refresh_from_db()
  File "/home/travis/build/druids/django-pynotify/.tox/venvs/py37-djangomaster/lib/python3.7/site-packages/chamber/models/__init__.py", line 456, in refresh_from_db
    if StrictVersion(django.get_version()) < StrictVersion('2.0'):
  File "/opt/python/3.7.1/lib/python3.7/distutils/version.py", line 40, in __init__
    self.parse(vstring)
  File "/opt/python/3.7.1/lib/python3.7/distutils/version.py", line 137, in parse
    raise ValueError("invalid version number '%s'" % vstring)
ValueError: invalid version number '3.0.dev20190416121426'
```
The `get_main_version()` function returns the version in format `(X.Y[.Z])`