### PR TITLE
Logging filter for hostname and extra JSON handler

### DIFF
--- a/chamber/utils/logging.py
+++ b/chamber/utils/logging.py
@@ -1,3 +1,8 @@
+import json
+import logging
+import platform
+
+from django.core.serializers.json import DjangoJSONEncoder
 from django.http import UnreadablePostError
 
 
@@ -7,3 +12,31 @@ def skip_unreadable_post(record):
         if isinstance(exc_value, UnreadablePostError):
             return False
     return True
+
+
+class AppendExtraJSONHandler(logging.StreamHandler):
+
+    DEFAULT_STREAM_HANDLER_VARIABLE_KEYS = {
+        'name', 'msg', 'args', 'levelname', 'levelno', 'pathname', 'filename', 'module', 'exc_info', 'exc_text',
+        'stack_info', 'lineno', 'funcName', 'created', 'msecs', 'relativeCreated', 'thread', 'threadName',
+        'processName', 'process',
+    }
+    CUSTOM_STREAM_HANDLER_VARIABLE_KEYS = {'hostname'}
+
+    def emit(self, record):
+        extra = {
+            k: v
+            for k, v in record.__dict__.items()
+            if k not in self.DEFAULT_STREAM_HANDLER_VARIABLE_KEYS.union(self.CUSTOM_STREAM_HANDLER_VARIABLE_KEYS)
+        }
+        record.msg = '{} --- {}'.format(record.msg, json.dumps(extra, cls=DjangoJSONEncoder))
+        super().emit(record)
+
+
+class HostnameFilter(logging.Filter):
+
+    hostname = platform.node()
+
+    def filter(self, record):
+        record.hostname = self.hostname
+        return True


### PR DESCRIPTION
The JSON handler serializes `extra` kwarg into JSON and appends the JSON
at the end of logged message after three dashes.

`<original message> --- <extra json>`