### PR TITLE
Set default value for json.dumps in logging AppendExtraJSONHandler

### DIFF
--- a/chamber/utils/logging.py
+++ b/chamber/utils/logging.py
@@ -29,7 +29,8 @@ class AppendExtraJSONHandler(logging.StreamHandler):
             for k, v in record.__dict__.items()
             if k not in self.DEFAULT_STREAM_HANDLER_VARIABLE_KEYS.union(self.CUSTOM_STREAM_HANDLER_VARIABLE_KEYS)
         }
-        record.msg = '{} --- {}'.format(record.msg, json.dumps(extra, cls=DjangoJSONEncoder))
+        record.msg = '{} --- {}'.format(record.msg, json.dumps(extra, cls=DjangoJSONEncoder,
+                                        default=lambda x: '<<NON-SERIALIZABLE TYPE: {}>>'.format(type(x).__qualname__)))
         super().emit(record)
 
 


### PR DESCRIPTION
Use default value when type cannot be serialized.