### PR TITLE
JSON encoder with defaults (for real)

### DIFF
--- a/chamber/utils/json.py
+++ b/chamber/utils/json.py
@@ -1,0 +1,16 @@
+from django.core.serializers.json import DjangoJSONEncoder
+
+
+class ChamberJSONEncoder(DjangoJSONEncoder):
+
+    def default(self, val):
+        if isinstance(val, bytes):
+            return {
+                '__type__': bytes.__name__,
+                '__value__': [x for x in val],
+            }
+        else:
+            try:
+                return super().default(val)
+            except TypeError:
+                return 'Unserializable value of "{}"'.format(str(type(val)))

--- a/chamber/utils/json.py
+++ b/chamber/utils/json.py
@@ -13,4 +13,8 @@ class ChamberJSONEncoder(DjangoJSONEncoder):
             try:
                 return super().default(val)
             except TypeError:
+                # https://github.com/python/cpython/blob/v3.8.3/Lib/json/encoder.py#L160-L180
                 return 'Unserializable value of "{}"'.format(str(type(val)))
+            except ValueError as ex:
+                # https://github.com/django/django/blob/2.2.14/django/core/serializers/json.py#L81-L104
+                return str(ex)

--- a/chamber/utils/json.py
+++ b/chamber/utils/json.py
@@ -4,17 +4,11 @@ from django.core.serializers.json import DjangoJSONEncoder
 class ChamberJSONEncoder(DjangoJSONEncoder):
 
     def default(self, val):
-        if isinstance(val, bytes):
-            return {
-                '__type__': bytes.__name__,
-                '__value__': [x for x in val],
-            }
-        else:
-            try:
-                return super().default(val)
-            except TypeError:
-                # https://github.com/python/cpython/blob/v3.8.3/Lib/json/encoder.py#L160-L180
-                return 'Unserializable value of "{}"'.format(str(type(val)))
-            except ValueError as ex:
-                # https://github.com/django/django/blob/2.2.14/django/core/serializers/json.py#L81-L104
-                return str(ex)
+        try:
+            return super().default(val)
+        except TypeError:
+            # https://github.com/python/cpython/blob/v3.8.3/Lib/json/encoder.py#L160-L180
+            return 'Unserializable value of "{}"'.format(str(type(val)))
+        except ValueError as ex:
+            # https://github.com/django/django/blob/2.2.14/django/core/serializers/json.py#L81-L104
+            return str(ex)

--- a/chamber/utils/logging.py
+++ b/chamber/utils/logging.py
@@ -2,8 +2,9 @@ import json
 import logging
 import platform
 
-from django.core.serializers.json import DjangoJSONEncoder
 from django.http import UnreadablePostError
+
+from chamber.utils.json import ChamberJSONEncoder
 
 
 def skip_unreadable_post(record):
@@ -29,7 +30,7 @@ class AppendExtraJSONHandler(logging.StreamHandler):
             for k, v in record.__dict__.items()
             if k not in self.DEFAULT_STREAM_HANDLER_VARIABLE_KEYS.union(self.CUSTOM_STREAM_HANDLER_VARIABLE_KEYS)
         }
-        record.msg = '{} --- {}'.format(record.msg, json.dumps(extra, cls=DjangoJSONEncoder))
+        record.msg = '{} --- {}'.format(record.msg, json.dumps(extra, cls=ChamberJSONEncoder))
         super().emit(record)
 
 


### PR DESCRIPTION
It outputs following for `datetime.datetime.now()` and `b'abc'`:
`'{"a": "2020-06-29T22:32:58.206", "b": {"__type__": "bytes", "__value__": [97, 98, 99]}}'`

I've realized we can't handle correctly extra attributes sent by any possible module...